### PR TITLE
Fix bug when ending with exception mark

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,23 @@ import type {
 import { checkEndsWithPeriod } from "check-ends-with-period";
 
 const checkEndsWithoutPeriod = (text: string, periodMarks: string[]) => {
-  const { index, periodMark, valid } = checkEndsWithPeriod(text, {
+  const { index, periodMark } = checkEndsWithPeriod(text, {
     periodMarks,
   });
+
+  const isPeriodMarkAtEnd = periodMarks.indexOf(periodMark) !== -1;
+  if (isPeriodMarkAtEnd) {
+    return {
+      index,
+      periodMark,
+      valid: false,
+    };
+  }
 
   return {
     index,
     periodMark,
-    valid: !valid,
+    valid: true,
   };
 };
 
@@ -54,10 +63,11 @@ const reporter: TextlintRuleReporter<Options> = (context, options = {}) => {
       }
 
       // Prefer to use period
-      const { index, periodMark, valid } = checkEndsWithPeriod(text, {
+      const { index, periodMark, valid } = checkEndsWithoutPeriod(
+        text,
         periodMarks,
-      });
-      if (valid) {
+      );
+      if (!valid) {
         if (periodMark === preferPeriodMark) {
           return;
         }

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -29,6 +29,9 @@ tester.run("textlint-rule-period-in-header", rule, {
         periodMark: ".",
       },
     },
+    "# text!",
+    "# text?",
+    "# text (foobar)",
   ],
   invalid: [
     {


### PR DESCRIPTION
## What

Fix bug when ending with exception mark.

Example
```
$ cat sample.md
# foobar (hogefuga)

# foobar!

$ cat .textlintrc.json
{
  "rules": {
    "period-in-header": true
  }
}

$ pnpm exec textlint sample.md

/Users/ohakutsu/tmp/textlint/sample.md
  1:19  ✓ error  Should remove period mark(")") at end of header  period-in-header
  3:9   ✓ error  Should remove period mark("!") at end of header  period-in-header

✖ 2 problems (2 errors, 0 warnings)
✓ 2 fixable problems.
Try to run: $ textlint --fix [file]
```